### PR TITLE
Update app.py

### DIFF
--- a/demo/modelling/app.py
+++ b/demo/modelling/app.py
@@ -88,7 +88,9 @@ def find_hyperparams(
     X, y = _get_dataset(_load_config(config_file, "data"), splits=[split])[split]
     gs.fit(X, y)
     hyperparams = _param_grid_to_custom_format(gs.best_params_)
-    estimator = model.build_estimator(hyperparams)
+    param_grid.update(hyperparams)
+    estimator = model.build_estimator(param_grid)
+    estimator.fit(X, y)
     output_dir = _load_config(config_file, "export")["output_dir"]
     _save_versioned_estimator(estimator, hyperparams, output_dir)
 


### PR DESCRIPTION
Sebas cuando reconstruias el estimador despues del grid search no le estabas metiendo las clases de preprocesameinto solo lo del "regresor" y ademas se estaba guardando el modelo sin ser "fiteado" porque reescribias el estimador, caudno ibamos a evaluar el modelo estaba sin ser entrenado, o al menos eso me estaba pasando a mi y por eso no funcionaba el "eval"